### PR TITLE
feat: Implement Google OAuth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,10 @@ PORT=3000
 #JWT secret
 JWT_SECRET=thisisasamplesecret
 
+#Google auth
+GOOGLE_CLIENT_ID=sample_client_id
+GOOGLE_CLIENT_SECRET=sample_client_secret
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 DATABASE_URL="mongodb://janedoe:mypassword@localhost:5432/mydb?schema=sample"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "jsonwebtoken": "^9.0.0",
         "moment": "^2.29.4",
         "passport": "^0.6.0",
+        "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
         "prisma": "^4.12.0"
       },
@@ -26,6 +27,7 @@
         "@types/jsonwebtoken": "^9.0.1",
         "@types/node": "^18.15.11",
         "@types/passport": "^1.0.12",
+        "@types/passport-google-oauth20": "^2.0.11",
         "@types/passport-jwt": "^3.0.8",
         "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
@@ -1661,6 +1663,15 @@
       "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true
     },
+    "node_modules/@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/passport": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.12.tgz",
@@ -1668,6 +1679,17 @@
       "dev": true,
       "dependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-google-oauth20": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/passport-google-oauth20/-/passport-google-oauth20-2.0.11.tgz",
+      "integrity": "sha512-9XMT1GfwhZL7UQEiCepLef55RNPHkbrCtsU7rsWPTEOsmu5qVIW8nSemtB4p+P24CuOhA+IKkv8LsPThYghGww==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
       }
     },
     "node_modules/@types/passport-jwt": {
@@ -1679,6 +1701,17 @@
         "@types/express": "*",
         "@types/jsonwebtoken": "*",
         "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-oauth2": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.12.tgz",
+      "integrity": "sha512-RZg6cYTyEGinrZn/7REYQds6zrTxoBorX1/fdaz5UHzkG8xdFE7QQxkJagCr2ETzGII58FAFDmnmbTUVMrltNA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/passport-strategy": {
@@ -2454,6 +2487,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
@@ -5741,6 +5782,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -5953,6 +5999,17 @@
         "url": "https://github.com/sponsors/jaredhanson"
       }
     },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/passport-jwt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
@@ -5960,6 +6017,25 @@
       "dependencies": {
         "jsonwebtoken": "^9.0.0",
         "passport-strategy": "^1.0.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.7.0.tgz",
+      "integrity": "sha512-j2gf34szdTF2Onw3+76alNnaAExlUmHvkc7cL+cmaS5NzHzDP/BvFHJruueQ9XAeNOdpI+CH+PWid8RA7KCwAQ==",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-strategy": {
@@ -7189,6 +7265,11 @@
       "engines": {
         "node": ">=12.20"
       }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -8784,6 +8865,15 @@
       "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true
     },
+    "@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/passport": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.12.tgz",
@@ -8791,6 +8881,17 @@
       "dev": true,
       "requires": {
         "@types/express": "*"
+      }
+    },
+    "@types/passport-google-oauth20": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/passport-google-oauth20/-/passport-google-oauth20-2.0.11.tgz",
+      "integrity": "sha512-9XMT1GfwhZL7UQEiCepLef55RNPHkbrCtsU7rsWPTEOsmu5qVIW8nSemtB4p+P24CuOhA+IKkv8LsPThYghGww==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
       }
     },
     "@types/passport-jwt": {
@@ -8802,6 +8903,17 @@
         "@types/express": "*",
         "@types/jsonwebtoken": "*",
         "@types/passport-strategy": "*"
+      }
+    },
+    "@types/passport-oauth2": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.12.tgz",
+      "integrity": "sha512-RZg6cYTyEGinrZn/7REYQds6zrTxoBorX1/fdaz5UHzkG8xdFE7QQxkJagCr2ETzGII58FAFDmnmbTUVMrltNA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
       }
     },
     "@types/passport-strategy": {
@@ -9351,6 +9463,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "bcryptjs": {
       "version": "2.4.3",
@@ -11807,6 +11924,11 @@
         "path-key": "^3.0.0"
       }
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -11952,6 +12074,14 @@
         "utils-merge": "^1.0.1"
       }
     },
+    "passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
     "passport-jwt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
@@ -11959,6 +12089,18 @@
       "requires": {
         "jsonwebtoken": "^9.0.0",
         "passport-strategy": "^1.0.0"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.7.0.tgz",
+      "integrity": "sha512-j2gf34szdTF2Onw3+76alNnaAExlUmHvkc7cL+cmaS5NzHzDP/BvFHJruueQ9XAeNOdpI+CH+PWid8RA7KCwAQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
       }
     },
     "passport-strategy": {
@@ -12802,6 +12944,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
+    },
+    "uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jsonwebtoken": "^9.0.0",
     "moment": "^2.29.4",
     "passport": "^0.6.0",
+    "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
     "prisma": "^4.12.0"
   },
@@ -36,6 +37,7 @@
     "@types/jsonwebtoken": "^9.0.1",
     "@types/node": "^18.15.11",
     "@types/passport": "^1.0.12",
+    "@types/passport-google-oauth20": "^2.0.11",
     "@types/passport-jwt": "^3.0.8",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.57.1",

--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -1,10 +1,26 @@
 import passport from 'passport';
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { userService } from '../services';
+
+if (
+  !process.env.JWT_SECRET ||
+  !process.env.GOOGLE_CLIENT_ID ||
+  !process.env.GOOGLE_CLIENT_SECRET ||
+  !process.env.GOOGLE_CALLBACK_URL
+) {
+  throw new Error('Environment variables not set');
+}
 
 const jwtOptions = {
   secretOrKey: process.env.JWT_SECRET,
   jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+};
+
+const googleOptions = {
+  clientID: process.env.GOOGLE_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  callbackURL: '/auth/google/callback',
 };
 
 passport.use(
@@ -15,6 +31,25 @@ passport.use(
       return done(null, false);
     } catch (err) {
       return done(err, false);
+    }
+  })
+);
+
+passport.use(
+  new GoogleStrategy(googleOptions, async (accessToken: any, refreshToken: any, profile: any, done: any) => {
+    try {
+      let user = await userService.getUserByGoogleId(profile.id);
+      if (!user) {
+        user = await userService.createUser({
+          googleId: profile.id,
+          email: profile.emails[0].value,
+          name: profile.displayName,
+        });
+      }
+
+      return done(null, user);
+    } catch (err) {
+      return done(err, null);
     }
   })
 );

--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -1,7 +1,7 @@
 import passport from 'passport';
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
-import { userService } from '../services';
+import { authService, userService } from '../services';
 
 if (
   !process.env.JWT_SECRET ||
@@ -35,23 +35,6 @@ passport.use(
   })
 );
 
-passport.use(
-  new GoogleStrategy(googleOptions, async (accessToken: any, refreshToken: any, profile: any, done: any) => {
-    try {
-      let user = await userService.getUserByGoogleId(profile.id);
-      if (!user) {
-        user = await userService.createUser({
-          googleId: profile.id,
-          email: profile.emails[0].value,
-          name: profile.displayName,
-        });
-      }
-
-      return done(null, user);
-    } catch (err) {
-      return done(err, null);
-    }
-  })
-);
+passport.use(new GoogleStrategy(googleOptions, authService.loginWithGoogle));
 
 export default passport;

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import moment from 'moment';
 import passport from 'passport';
 import catchAsync from '../utils/catchAsync';
@@ -17,23 +17,19 @@ const login = catchAsync(async (req: Request, res: Response) => {
   res.json({ user, token });
 });
 
-const logout = catchAsync(async (req: Request, res: Response) => {
-  return res.status(200).json({ message: 'Logging out...' });
-});
-
 const googleAuth = passport.authenticate('google', { scope: ['profile', 'email'] });
 
-const googleAuthCallback = catchAsync(async (req: any, res: any, next: any) => {
+const googleAuthCallback = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
   passport.authenticate('google', { session: false }, async (err, user) => {
-    if (err) {
-      return res.status(500).json({ message: 'Server error' });
-    }
-    if (!user) {
-      return res.status(401).json({ message: 'Authentication failed' });
-    }
-    const token = await tokenService.generateAccessToken(user, moment().add(1, 'hours'));
+    if (err) return res.status(500).json({ message: 'Server error' });
+    if (!user) return res.status(401).json({ message: 'Authentication failed' });
+    const token = await tokenService.generateAccessToken(user, moment().add(30, 'minutes'));
     return res.json({ user, token });
   })(req, res, next);
+});
+
+const logout = catchAsync(async (req: Request, res: Response) => {
+  return res.status(200).json({ message: 'Logging out...' });
 });
 
 const authController = {

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -1,20 +1,18 @@
 import express from 'express';
 import passport from 'passport';
-import jwt from 'jsonwebtoken';
 import { authController, userController } from '../controllers';
 
 const router = express.Router();
 
 router.post('/register', authController.register);
 router.post('/login', authController.login);
+router.get('/google', authController.googleAuth);
+router.get('/google/callback', authController.googleAuthCallback);
 router.post('/logout', authController.logout);
 router.get('/users', userController.getUsers);
 
 router.get('/secret', passport.authenticate('jwt', { session: false }), (req, res) => {
   res.json(req.user);
 });
-
-router.get('/google', authController.googleAuth);
-router.get('/google/callback', authController.googleAuthCallback);
 
 export default router;

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -14,19 +14,7 @@ router.get('/secret', passport.authenticate('jwt', { session: false }), (req, re
   res.json(req.user);
 });
 
-router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
-
-router.get('/google/callback', (req, res, next) => {
-  passport.authenticate('google', { session: false }, (err, user) => {
-    if (err) {
-      return res.status(500).json({ message: 'Server error' });
-    }
-    if (!user) {
-      return res.status(401).json({ message: 'Authentication failed' });
-    }
-    const token = jwt.sign({ sub: user.id }, process.env.JWT_SECRET as string, { expiresIn: '1h' });
-    return res.json({ user, token });
-  })(req, res, next);
-});
+router.get('/google', authController.googleAuth);
+router.get('/google/callback', authController.googleAuthCallback);
 
 export default router;

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import passport from 'passport';
+import jwt from 'jsonwebtoken';
 import { authController, userController } from '../controllers';
 
 const router = express.Router();
@@ -11,6 +12,21 @@ router.get('/users', userController.getUsers);
 
 router.get('/secret', passport.authenticate('jwt', { session: false }), (req, res) => {
   res.json(req.user);
+});
+
+router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+router.get('/google/callback', (req, res, next) => {
+  passport.authenticate('google', { session: false }, (err, user) => {
+    if (err) {
+      return res.status(500).json({ message: 'Server error' });
+    }
+    if (!user) {
+      return res.status(401).json({ message: 'Authentication failed' });
+    }
+    const token = jwt.sign({ sub: user.id }, process.env.JWT_SECRET as string, { expiresIn: '1h' });
+    return res.json({ user, token });
+  })(req, res, next);
 });
 
 export default router;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -7,8 +7,27 @@ const loginWithCredentials = async (email: string, password: string) => {
   throw new Error('Invalid email or password');
 };
 
+const loginWithGoogle = async (accessToken: string, refreshToken: string, profile: any, done: any) => {
+  try {
+    const user = await userService.getUserByGoogleId(profile.id);
+
+    if (user) {
+      return done(null, user);
+    }
+    const newUser = await userService.createUser({
+      googleId: profile.id,
+      email: profile.emails[0].value,
+      name: profile.displayName,
+    });
+    return done(null, newUser);
+  } catch (error) {
+    return done(error);
+  }
+};
+
 const authService = {
   loginWithCredentials,
+  loginWithGoogle,
 };
 
 export default authService;

--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -1,10 +1,11 @@
 import jwt from 'jsonwebtoken';
-import moment from 'moment';
+import moment, { Moment } from 'moment';
+import { User } from '@prisma/client';
 
 const { JWT_SECRET } = process.env;
 if (!JWT_SECRET) throw new Error('JWT secret is not defined');
 
-const generateAccessToken = (user: any, expires: any, secret = JWT_SECRET) => {
+const generateAccessToken = (user: User, expires: Moment, secret = JWT_SECRET) => {
   const payload = {
     sub: user.id,
     iat: moment().unix(),

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -3,9 +3,10 @@ import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
-const createUser = async (userBody: User) => {
-  const hashedPassword = userBody.password && (await bcrypt.hash(userBody.password, 10));
-  const user = await prisma.user.create({ data: { ...userBody, password: hashedPassword } });
+const createUser = async (userBody: any) => {
+  const newUser = { ...userBody };
+  if (newUser.password) newUser.password = await bcrypt.hash(newUser.password, 10);
+  const user = await prisma.user.create({ data: { ...newUser } });
   return user;
 };
 


### PR DESCRIPTION
- Installing passport-google-oauth20 and related types for Google authentication.
- Adding Google OAuth credentials and callback URL to the .env.example file.
- Setting up basic configuration, routes, and services for Google authentication.
- Refactoring Google authentication code for better organization and style.
- Improving code readability and tidiness across multiple files.